### PR TITLE
Add metadata as string, serialize/deserialize data

### DIFF
--- a/mypetpal-api/Data/Common/Interface/Common.cs
+++ b/mypetpal-api/Data/Common/Interface/Common.cs
@@ -3,7 +3,9 @@
     public interface IMetadata
         {         
             DateTime? Metadata_createdUtc { get; set; }
+
             DateTime? Metadata_deletedUtc { get; set; }
+
             DateTime? Metadata_updatedUtc { get; set; }
         }
     

--- a/mypetpal-api/Data/dbContext.cs
+++ b/mypetpal-api/Data/dbContext.cs
@@ -41,9 +41,6 @@ namespace mypetpal.dbContext
             modelBuilder.Entity<PetAttributes>()
                 .HasKey(pa => pa.PetId);
 
-            modelBuilder.Ignore<PetMetadata>();
-
-            modelBuilder.Ignore<UserMetadata>();
 
             base.OnModelCreating(modelBuilder);
         }

--- a/mypetpal-api/Migrations/20240924054224_Migration24Sep-1.Designer.cs
+++ b/mypetpal-api/Migrations/20240924054224_Migration24Sep-1.Designer.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using mypetpal.dbContext;
 
@@ -10,9 +11,11 @@ using mypetpal.dbContext;
 namespace mypetpalapi.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240924054224_Migration24Sep-1")]
+    partial class Migration24Sep1
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/mypetpal-api/Migrations/20240924054224_Migration24Sep-1.cs
+++ b/mypetpal-api/Migrations/20240924054224_Migration24Sep-1.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace mypetpalapi.Migrations
+{
+    /// <inheritdoc />
+    public partial class Migration24Sep1 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Metadata",
+                table: "Users",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Metadata",
+                table: "PetAttributes",
+                type: "nvarchar(1000)",
+                maxLength: 1000,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Metadata",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "Metadata",
+                table: "PetAttributes");
+        }
+    }
+}

--- a/mypetpal-api/Models/PetAttributes.cs
+++ b/mypetpal-api/Models/PetAttributes.cs
@@ -26,7 +26,8 @@ namespace mypetpal.Models
         [Required]
         public PetStatus PetStatus { get; set; }
 
-        public PetMetadata Metadata { get; set; } = new PetMetadata();
+        [MaxLength(1000)]
+        public string? Metadata { get; set; }
 
         [MaxLength(250)]
         public string PetAvatar { get; set; }
@@ -38,6 +39,22 @@ namespace mypetpal.Models
         public int Health { get; set; }
 
         public int Happiness { get; set; }
+
+        // Deserialize JSON string to PetMetadata object
+        public PetMetadata GetPetMetadata()
+        {
+            if (string.IsNullOrEmpty(Metadata))
+            {
+                return new PetMetadata();
+            }
+            return System.Text.Json.JsonSerializer.Deserialize<PetMetadata>(Metadata);
+        }
+
+        // Serialize PetMetadata object to JSON string
+        public void SetPetMetadata(PetMetadata metadata)
+        {
+            Metadata = System.Text.Json.JsonSerializer.Serialize(metadata);
+        }
     }
 
 
@@ -49,7 +66,5 @@ namespace mypetpal.Models
 
         public DateTime? Metadata_updatedUtc { get; set; }
     }
-
-    
 }
 

--- a/mypetpal-api/Models/User.cs
+++ b/mypetpal-api/Models/User.cs
@@ -17,7 +17,21 @@ namespace mypetpal.Models
         [MaxLength(100)]
         public string Email { get; set; }
 
-        public UserMetadata? Metadata { get; set; }
+        public string? Metadata { get; set; }
+
+        public UserMetadata GetUserMetadata()
+        {
+            if (string.IsNullOrEmpty(Metadata))
+            {
+                return new UserMetadata();
+            }
+            return System.Text.Json.JsonSerializer.Deserialize<UserMetadata>(Metadata);
+        }
+
+        public void SetUserMetadata(UserMetadata metadata)
+        {
+            Metadata = System.Text.Json.JsonSerializer.Serialize(metadata);
+        }
     }
 
 

--- a/mypetpal-api/mypetpal-api.csproj
+++ b/mypetpal-api/mypetpal-api.csproj
@@ -35,12 +35,8 @@
     <Folder Include="Controllers\" />
     <Folder Include="Models\" />
     <Folder Include="Data\" />
-    <Folder Include="wwwroot\" />
     <Folder Include="Data\Common\" />
     <Folder Include="Data\Common\Interface\" />
     <Folder Include="Data\Common\Enums\" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Remove="wwwroot\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Metadata field is now a string in the DB. This is so that we don't have to store the Metadata type class in the DB